### PR TITLE
Watchlist api

### DIFF
--- a/Postman tests/Media Watchlist API calls.json
+++ b/Postman tests/Media Watchlist API calls.json
@@ -1,0 +1,526 @@
+{
+	"info": {
+		"_postman_id": "908a5915-2cc4-4374-8d2d-69754a04353f",
+		"name": "Media Watchlist",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Auth Token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"",
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.environment.set(\"authToken\", jsonData.accessToken);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "3%MXC<+fDbqdgVW",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "rbird5@jh.edu",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/auth/token",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"auth",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Media By Id",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/media/tt0461770",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"media",
+						"tt0461770"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Media By Query",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/media?query=tt0461770",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"media"
+					],
+					"query": [
+						{
+							"key": "query",
+							"value": "tt0461770"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Users",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create Watchlist",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"",
+							"pm.test(\"Status code is 201\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.environment.set(\"lastCreatedWatchlistId\", jsonData.id);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"ownerUserId\": \"{{rbirdUserId}}\",\n    \"isPubliclyViewable\": true,\n    \"mediaItems\": [\n        { \"id\": \"tt0461770\"},\n        { \"name\": \"Frozen\"}\n    ]\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Watchlist",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist/{{lastCreatedWatchlistId}}",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist",
+						"{{lastCreatedWatchlistId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Media to Watchlist By Id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"",
+							"pm.test(\"Status code is 201\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.environment.set(\"lastCreatedWatchlistId\", jsonData.id);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"tt0120762\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist/{{lastCreatedWatchlistId}}/media",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist",
+						"{{lastCreatedWatchlistId}}",
+						"media"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Media to Watchlist By Name",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"",
+							"pm.test(\"Status code is 201\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.environment.set(\"lastCreatedWatchlistId\", jsonData.id);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": \"Sleeping Beauty\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist/{{lastCreatedWatchlistId}}/media",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist",
+						"{{lastCreatedWatchlistId}}",
+						"media"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete MediaItem (Enchanted) From Watchlist",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist/{{lastCreatedWatchlistId}}/media/tt0461770",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist",
+						"{{lastCreatedWatchlistId}}",
+						"media",
+						"tt0461770"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Set Watchlist Visibility",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"",
+							"pm.test(\"Status code is 201\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.environment.set(\"lastCreatedWatchlistId\", jsonData.id);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"isPubliclyViewable\": false\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/MovieWatchlistAPI/1.0.0/watchlist/{{lastCreatedWatchlistId}}/visibility",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"MovieWatchlistAPI",
+						"1.0.0",
+						"watchlist",
+						"{{lastCreatedWatchlistId}}",
+						"visibility"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/main/java/io/swagger/api/watchlist/WatchlistApi.java
+++ b/src/main/java/io/swagger/api/watchlist/WatchlistApi.java
@@ -7,6 +7,8 @@ package io.swagger.api.watchlist;
 
 import io.swagger.model.media.MediaItem;
 import io.swagger.model.watchlist.Watchlist;
+import io.swagger.model.watchlist.WatchlistCreateRequest;
+import io.swagger.model.watchlist.WatchlistVisiblity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.validation.Valid;
+import java.util.UUID;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2022-04-02T22:43:09.213512-04:00[America/New_York]")
 @Validated
@@ -33,7 +36,7 @@ public interface WatchlistApi {
     @RequestMapping(value = "/watchlist",
         produces = { "application/json", "application/xml" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Watchlist> watchlistPost();
+    ResponseEntity<Watchlist> watchlistPost(@Parameter(in = ParameterIn.DEFAULT, description = "Watchlist to create", schema=@Schema()) @Valid @RequestBody WatchlistCreateRequest body);
 
 
     @Operation(summary = "Retrieve Watchlist", description = "Gets an existing watchlist for the calling user if watchlist exists and the user has permissions to view the Watchlist. ", tags={ "Watchlist" })
@@ -44,7 +47,7 @@ public interface WatchlistApi {
     @RequestMapping(value = "/watchlist/{watchlist_id}",
         produces = { "application/json", "application/xml" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Watchlist> watchlistWatchlistIdGet(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId);
+    ResponseEntity<Watchlist> watchlistWatchlistIdGet(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId);
 
 
     @Operation(summary = "Set Visibility", description = "Sets the IsPublic attribute for the watchlist ", tags={ "Watchlist" })
@@ -54,7 +57,7 @@ public interface WatchlistApi {
         @ApiResponse(responseCode = "404", description = "Watchlist or Media not found for user") })
     @RequestMapping(value = "/watchlist/{watchlist_id}/media/{media_id}",
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> watchlistWatchlistIdMediaMediaIdDelete(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId, @Parameter(in = ParameterIn.PATH, description = "The id of the media to delete", required=true, schema=@Schema()) @PathVariable("media_id") Integer mediaId);
+    ResponseEntity<Void> watchlistWatchlistIdMediaMediaIdDelete(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId, @Parameter(in = ParameterIn.PATH, description = "The id of the media to delete", required=true, schema=@Schema()) @PathVariable("media_id") String mediaId);
 
 
     @Operation(summary = "Adds Media", description = "Adds a media object to the watchlist ", tags={ "Watchlist" })
@@ -66,7 +69,7 @@ public interface WatchlistApi {
         produces = { "application/json", "application/xml" }, 
         consumes = { "application/json", "application/xml" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Watchlist> watchlistWatchlistIdMediaPost(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId, @Parameter(in = ParameterIn.DEFAULT, description = "Media data to add to watchlist", schema=@Schema()) @Valid @RequestBody MediaItem body);
+    ResponseEntity<Watchlist> watchlistWatchlistIdMediaPost(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId, @Parameter(in = ParameterIn.DEFAULT, description = "Media data to add to watchlist", schema=@Schema()) @Valid @RequestBody MediaItem body);
 
 
     @Operation(summary = "Set Visibility", description = "Sets the IsPublic attribute for the watchlist ", tags={ "Watchlist" })
@@ -78,7 +81,7 @@ public interface WatchlistApi {
         produces = { "application/json", "application/xml" }, 
         consumes = { "application/json", "application/xml" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Watchlist> watchlistWatchlistIdVisibilityPut(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId, @Parameter(in = ParameterIn.DEFAULT, description = "", schema=@Schema()) @Valid @RequestBody Object body);
+    ResponseEntity<Watchlist> watchlistWatchlistIdVisibilityPut(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId, @Parameter(in = ParameterIn.DEFAULT, description = "", schema=@Schema()) @Valid @RequestBody WatchlistVisiblity body);
 
 }
 

--- a/src/main/java/io/swagger/api/watchlist/WatchlistApiController.java
+++ b/src/main/java/io/swagger/api/watchlist/WatchlistApiController.java
@@ -3,6 +3,9 @@ package io.swagger.api.watchlist;
 import io.swagger.model.media.MediaItem;
 import io.swagger.model.watchlist.Watchlist;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.model.watchlist.WatchlistCreateRequest;
+import io.swagger.model.watchlist.WatchlistVisiblity;
+import io.swagger.service.WatchlistService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import javax.validation.Valid;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2022-04-02T22:43:09.213512-04:00[America/New_York]")
 @RestController
@@ -28,71 +33,56 @@ public class WatchlistApiController implements WatchlistApi {
 
     private final HttpServletRequest request;
 
+    private final WatchlistService watchlistService;
+
     @org.springframework.beans.factory.annotation.Autowired
-    public WatchlistApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+    public WatchlistApiController(ObjectMapper objectMapper, HttpServletRequest request, WatchlistService watchlistService) {
         this.objectMapper = objectMapper;
         this.request = request;
+        this.watchlistService = watchlistService;
     }
 
-    public ResponseEntity<Watchlist> watchlistPost() {
-        String accept = request.getHeader("Accept");
-        if (accept != null && accept.contains("application/json")) {
-            try {
-                return new ResponseEntity<Watchlist>(objectMapper.readValue("{\n  \"mediaItems\" : [ {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  }, {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  } ],\n  \"isPubliclyViewable\" : true,\n  \"ownerUserId\" : 3,\n  \"id\" : 1\n}", Watchlist.class), HttpStatus.NOT_IMPLEMENTED);
-            } catch (IOException e) {
-                log.error("Couldn't serialize response for content type application/json", e);
-                return new ResponseEntity<Watchlist>(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+    public ResponseEntity<Watchlist> watchlistPost(@Parameter(in = ParameterIn.DEFAULT, description = "Watchlist to create", schema=@Schema()) @Valid @RequestBody WatchlistCreateRequest body) {
+        Watchlist watchlist = watchlistService.CreateWatchlist(body);
+
+        // TODO: Add links for individual media items
+
+        return ResponseEntity.created(URI.create("/watchlist/" + watchlist.getId())).body(watchlist);
+    }
+
+    public ResponseEntity<Watchlist> watchlistWatchlistIdGet(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId) {
+        Watchlist watchlist = watchlistService.GetWatchlistById(watchlistId);
+
+        if (watchlist == null) {
+            return ResponseEntity.notFound().build();
         }
 
-        return new ResponseEntity<Watchlist>(HttpStatus.NOT_IMPLEMENTED);
+        return ResponseEntity.ok(watchlist);
     }
 
-    public ResponseEntity<Watchlist> watchlistWatchlistIdGet(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId) {
-        String accept = request.getHeader("Accept");
-        if (accept != null && accept.contains("application/json")) {
-            try {
-                return new ResponseEntity<Watchlist>(objectMapper.readValue("{\n  \"mediaItems\" : [ {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  }, {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  } ],\n  \"isPubliclyViewable\" : true,\n  \"ownerUserId\" : 3,\n  \"id\" : 1\n}", Watchlist.class), HttpStatus.NOT_IMPLEMENTED);
-            } catch (IOException e) {
-                log.error("Couldn't serialize response for content type application/json", e);
-                return new ResponseEntity<Watchlist>(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+    public ResponseEntity<Void> watchlistWatchlistIdMediaMediaIdDelete(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId,@Parameter(in = ParameterIn.PATH, description = "The id of the media to delete", required=true, schema=@Schema()) @PathVariable("media_id") String mediaId) {
+        watchlistService.RemoveMediaFromWatchlist(watchlistId, mediaId);
+        return ResponseEntity.ok().build();
+    }
+
+    public ResponseEntity<Watchlist> watchlistWatchlistIdMediaPost(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId,@Parameter(in = ParameterIn.DEFAULT, description = "Media data to add to watchlist", schema=@Schema()) @Valid @RequestBody MediaItem body) {
+        Watchlist watchlist = watchlistService.AddMediaItemToWatchlist(watchlistId, body);
+
+        if (watchlist == null) {
+            return ResponseEntity.notFound().build();
         }
 
-        return new ResponseEntity<Watchlist>(HttpStatus.NOT_IMPLEMENTED);
+        return ResponseEntity.ok(watchlist);
     }
 
-    public ResponseEntity<Void> watchlistWatchlistIdMediaMediaIdDelete(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId,@Parameter(in = ParameterIn.PATH, description = "The id of the media to delete", required=true, schema=@Schema()) @PathVariable("media_id") Integer mediaId) {
-        String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
-    }
+    public ResponseEntity<Watchlist> watchlistWatchlistIdVisibilityPut(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") UUID watchlistId,@Parameter(in = ParameterIn.DEFAULT, description = "", schema=@Schema()) @Valid @RequestBody WatchlistVisiblity body) {
+        Watchlist watchlist = watchlistService.SetWatchlistVisibility(watchlistId, body);
 
-    public ResponseEntity<Watchlist> watchlistWatchlistIdMediaPost(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId,@Parameter(in = ParameterIn.DEFAULT, description = "Media data to add to watchlist", schema=@Schema()) @Valid @RequestBody MediaItem body) {
-        String accept = request.getHeader("Accept");
-        if (accept != null && accept.contains("application/json")) {
-            try {
-                return new ResponseEntity<Watchlist>(objectMapper.readValue("{\n  \"mediaItems\" : [ {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  }, {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  } ],\n  \"isPubliclyViewable\" : true,\n  \"ownerUserId\" : 3,\n  \"id\" : 1\n}", Watchlist.class), HttpStatus.NOT_IMPLEMENTED);
-            } catch (IOException e) {
-                log.error("Couldn't serialize response for content type application/json", e);
-                return new ResponseEntity<Watchlist>(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+        if (watchlist == null) {
+            return ResponseEntity.notFound().build();
         }
 
-        return new ResponseEntity<Watchlist>(HttpStatus.NOT_IMPLEMENTED);
-    }
-
-    public ResponseEntity<Watchlist> watchlistWatchlistIdVisibilityPut(@Parameter(in = ParameterIn.PATH, description = "The id of the watchlist to retrieve", required=true, schema=@Schema()) @PathVariable("watchlist_id") Integer watchlistId,@Parameter(in = ParameterIn.DEFAULT, description = "", schema=@Schema()) @Valid @RequestBody Object body) {
-        String accept = request.getHeader("Accept");
-        if (accept != null && accept.contains("application/json")) {
-            try {
-                return new ResponseEntity<Watchlist>(objectMapper.readValue("{\n  \"mediaItems\" : [ {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  }, {\n    \"name\" : \"The Good Doctor\",\n    \"id\" : 5\n  } ],\n  \"isPubliclyViewable\" : true,\n  \"ownerUserId\" : 3,\n  \"id\" : 1\n}", Watchlist.class), HttpStatus.NOT_IMPLEMENTED);
-            } catch (IOException e) {
-                log.error("Couldn't serialize response for content type application/json", e);
-                return new ResponseEntity<Watchlist>(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-        }
-
-        return new ResponseEntity<Watchlist>(HttpStatus.NOT_IMPLEMENTED);
+        return ResponseEntity.ok(watchlist);
     }
 
 }

--- a/src/main/java/io/swagger/entity/watchlist/WatchlistEntity.java
+++ b/src/main/java/io/swagger/entity/watchlist/WatchlistEntity.java
@@ -1,0 +1,32 @@
+package io.swagger.entity.watchlist;
+
+import io.swagger.entity.media.MediaCache;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.UUID;
+
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchlistEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private Boolean isPubliclyViewable;
+    private UUID ownerUserId;
+
+    // Since TitleData is stored as blob data, saving and retrieving is quite crazy
+//    // Media Ids are stored in "query" column
+//    @ManyToMany
+//    @JoinColumn(name = "query", referencedColumnName = "id")
+//    private List<MediaCache> mediaItems;
+}

--- a/src/main/java/io/swagger/entity/watchlist/WatchlistMedia.java
+++ b/src/main/java/io/swagger/entity/watchlist/WatchlistMedia.java
@@ -1,0 +1,24 @@
+package io.swagger.entity.watchlist;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchlistMedia {
+    // JPA requires an ID. Make it an integer for now for simplicity.
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private UUID WatchlistId;
+    private String MediaId;
+}

--- a/src/main/java/io/swagger/model/media/MediaItem.java
+++ b/src/main/java/io/swagger/model/media/MediaItem.java
@@ -16,12 +16,12 @@ import javax.validation.constraints.*;
 
 public class MediaItem   {
   @JsonProperty("id")
-  private Integer id = null;
+  private String id = null;
 
   @JsonProperty("name")
   private String name = null;
 
-  public MediaItem id(Integer id) {
+  public MediaItem id(String id) {
     this.id = id;
     return this;
   }
@@ -30,14 +30,13 @@ public class MediaItem   {
    * Get id
    * @return id
    **/
-  @Schema(example = "5", required = true, description = "")
-      @NotNull
+  @Schema(example = "5", required = false, description = "")
 
-    public Integer getId() {
+    public String getId() {
     return id;
   }
 
-  public void setId(Integer id) {
+  public void setId(String id) {
     this.id = id;
   }
 
@@ -50,8 +49,7 @@ public class MediaItem   {
    * Get name
    * @return name
    **/
-  @Schema(example = "The Good Doctor", required = true, description = "")
-      @NotNull
+  @Schema(example = "The Good Doctor", required = false, description = "")
 
     public String getName() {
     return name;

--- a/src/main/java/io/swagger/model/watchlist/WatchlistCreateRequest.java
+++ b/src/main/java/io/swagger/model/watchlist/WatchlistCreateRequest.java
@@ -1,28 +1,25 @@
 package io.swagger.model.watchlist;
 
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.model.media.MediaItem;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
-import org.springframework.validation.annotation.Validated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-
 /**
- * Watchlist
+ * WatchlistCreateRequest
  */
 @Validated
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2022-04-02T22:43:09.213512-04:00[America/New_York]")
 
 
-public class Watchlist   {
-  @JsonProperty("id")
-  private UUID id = null;
-
+public class WatchlistCreateRequest {
   @JsonProperty("isPubliclyViewable")
   private Boolean isPubliclyViewable = null;
 
@@ -33,27 +30,7 @@ public class Watchlist   {
   @Valid
   private List<MediaItem> mediaItems = new ArrayList<MediaItem>();
 
-  public Watchlist id(UUID id) {
-    this.id = id;
-    return this;
-  }
-
-  /**
-   * Get id
-   * @return id
-   **/
-  @Schema(example = "1", required = true, description = "")
-      @NotNull
-
-    public UUID getId() {
-    return id;
-  }
-
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
-  public Watchlist isPubliclyViewable(Boolean isPubliclyViewable) {
+  public WatchlistCreateRequest isPubliclyViewable(Boolean isPubliclyViewable) {
     this.isPubliclyViewable = isPubliclyViewable;
     return this;
   }
@@ -73,7 +50,7 @@ public class Watchlist   {
     this.isPubliclyViewable = isPubliclyViewable;
   }
 
-  public Watchlist ownerUserId(UUID ownerUserId) {
+  public WatchlistCreateRequest ownerUserId(UUID ownerUserId) {
     this.ownerUserId = ownerUserId;
     return this;
   }
@@ -93,12 +70,12 @@ public class Watchlist   {
     this.ownerUserId = ownerUserId;
   }
 
-  public Watchlist mediaItems(List<MediaItem> mediaItems) {
+  public WatchlistCreateRequest mediaItems(List<MediaItem> mediaItems) {
     this.mediaItems = mediaItems;
     return this;
   }
 
-  public Watchlist addMediaItemsItem(MediaItem mediaItemsItem) {
+  public WatchlistCreateRequest addMediaItemsItem(MediaItem mediaItemsItem) {
     this.mediaItems.add(mediaItemsItem);
     return this;
   }
@@ -120,31 +97,29 @@ public class Watchlist   {
 
 
   @Override
-  public boolean equals(java.lang.Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Watchlist watchlist = (Watchlist) o;
-    return Objects.equals(this.id, watchlist.id) &&
-        Objects.equals(this.isPubliclyViewable, watchlist.isPubliclyViewable) &&
+    WatchlistCreateRequest watchlist = (WatchlistCreateRequest) o;
+    return Objects.equals(this.isPubliclyViewable, watchlist.isPubliclyViewable) &&
         Objects.equals(this.ownerUserId, watchlist.ownerUserId) &&
         Objects.equals(this.mediaItems, watchlist.mediaItems);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, isPubliclyViewable, ownerUserId, mediaItems);
+    return Objects.hash(isPubliclyViewable, ownerUserId, mediaItems);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class Watchlist {\n");
+    sb.append("class WatchlistCreateRequest {\n");
     
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    isPubliclyViewable: ").append(toIndentedString(isPubliclyViewable)).append("\n");
     sb.append("    ownerUserId: ").append(toIndentedString(ownerUserId)).append("\n");
     sb.append("    mediaItems: ").append(toIndentedString(mediaItems)).append("\n");
@@ -156,7 +131,7 @@ public class Watchlist   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(java.lang.Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/src/main/java/io/swagger/model/watchlist/WatchlistVisiblity.java
+++ b/src/main/java/io/swagger/model/watchlist/WatchlistVisiblity.java
@@ -1,0 +1,70 @@
+package io.swagger.model.watchlist;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+public class WatchlistVisiblity {
+    @JsonProperty("isPubliclyViewable")
+    private Boolean isPubliclyViewable = null;
+
+    public WatchlistVisiblity isPubliclyViewable(Boolean isPubliclyViewable) {
+        this.isPubliclyViewable = isPubliclyViewable;
+        return this;
+    }
+
+    /**
+     * Get isPubliclyViewable
+     * @return isPubliclyViewable
+     **/
+    @Schema(example = "true", required = true, description = "")
+    @NotNull
+
+    public Boolean isIsPubliclyViewable() {
+        return isPubliclyViewable;
+    }
+
+    public void setIsPubliclyViewable(Boolean isPubliclyViewable) {
+        this.isPubliclyViewable = isPubliclyViewable;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WatchlistVisiblity watchlistVisiblity = (WatchlistVisiblity) o;
+        return Objects.equals(this.isPubliclyViewable, watchlistVisiblity.isPubliclyViewable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isPubliclyViewable);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WatchlistVisiblity {\n");
+
+        sb.append("    isPubliclyViewable: ").append(toIndentedString(isPubliclyViewable)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/src/main/java/io/swagger/repository/WatchlistMediaRepository.java
+++ b/src/main/java/io/swagger/repository/WatchlistMediaRepository.java
@@ -1,0 +1,13 @@
+package io.swagger.repository;
+
+import io.swagger.entity.watchlist.WatchlistMedia;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WatchlistMediaRepository extends CrudRepository<WatchlistMedia, Integer> {
+    @Query("SELECT w FROM WatchlistMedia w WHERE w.WatchlistId = ?1")
+    List<WatchlistMedia> findAllByWatchlistId(UUID WatchlistId);
+}

--- a/src/main/java/io/swagger/repository/WatchlistRepository.java
+++ b/src/main/java/io/swagger/repository/WatchlistRepository.java
@@ -1,0 +1,9 @@
+package io.swagger.repository;
+
+import io.swagger.entity.watchlist.WatchlistEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+public interface WatchlistRepository extends CrudRepository<WatchlistEntity, UUID> {
+}

--- a/src/main/java/io/swagger/service/MediaService.java
+++ b/src/main/java/io/swagger/service/MediaService.java
@@ -2,6 +2,7 @@ package io.swagger.service;
 
 import io.swagger.entity.media.MediaRating;
 import io.swagger.model.media.SearchData;
+import io.swagger.model.media.SearchResult;
 import io.swagger.model.media.TitleData;
 import io.swagger.model.media.UserRating;
 import io.swagger.repository.ImdbCacheRepository;
@@ -75,6 +76,22 @@ public class MediaService {
         }
 
         return imdbData;
+    }
+
+    // Centralized function for finding a specific title in a list
+    // of results
+    public SearchResult getSearchResultByTitle(String title) {
+        SearchData data = getMediaByTitle(title);
+
+        if (data == null) {
+            return null;
+        }
+
+        // find title that matches exactly ignoring case
+        return data.getResults().stream().
+                filter(result -> result.getTitle().equalsIgnoreCase(title))
+                .findFirst()
+                .orElse(null);
     }
 
     public void rateMediaById(String titleId, int rating) {

--- a/src/main/java/io/swagger/service/MovieUserDetailsService.java
+++ b/src/main/java/io/swagger/service/MovieUserDetailsService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 public class MovieUserDetailsService implements UserDetailsService {
@@ -34,6 +35,22 @@ public class MovieUserDetailsService implements UserDetailsService {
 
         return new org.springframework.security.core.userdetails.User(
                 email,
+                user.get().getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(role)));
+    }
+
+    public UserDetails loadUserById(UUID id) {
+        Optional<User> user = userRepository.findById(id);
+
+        if (user.isEmpty()) {
+            //throw new UsernameNotFoundException("Could not find user with id = " + id);
+            return null;
+        }
+
+        String role = user.get().isAdmin() ? "ROLE_ADMIN" : "ROLE_USER";
+
+        return new org.springframework.security.core.userdetails.User(
+                user.get().getEmail(),
                 user.get().getPassword(),
                 Collections.singletonList(new SimpleGrantedAuthority(role)));
     }

--- a/src/main/java/io/swagger/service/WatchlistService.java
+++ b/src/main/java/io/swagger/service/WatchlistService.java
@@ -1,0 +1,210 @@
+package io.swagger.service;
+
+import io.swagger.entity.watchlist.WatchlistEntity;
+import io.swagger.entity.watchlist.WatchlistMedia;
+import io.swagger.model.media.MediaItem;
+import io.swagger.model.media.SearchData;
+import io.swagger.model.media.SearchResult;
+import io.swagger.model.media.TitleData;
+import io.swagger.model.watchlist.Watchlist;
+import io.swagger.model.watchlist.WatchlistCreateRequest;
+import io.swagger.model.watchlist.WatchlistVisiblity;
+import io.swagger.repository.WatchlistMediaRepository;
+import io.swagger.repository.WatchlistRepository;
+import org.springframework.data.domain.Example;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class WatchlistService {
+
+    private final WatchlistRepository watchlistRepository;
+    private final WatchlistMediaRepository watchlistMediaRepository;
+
+    private final MediaService mediaService;
+
+    public WatchlistService(WatchlistRepository watchlistRepository,
+                            WatchlistMediaRepository watchlistMediaRepository,
+                            MediaService mediaService) {
+        this.watchlistRepository = watchlistRepository;
+        this.watchlistMediaRepository = watchlistMediaRepository;
+        this.mediaService = mediaService;
+    }
+
+    public Watchlist CreateWatchlist(WatchlistCreateRequest watchlistRequest) {
+        // TODO: Validate input data
+
+        Watchlist watchlist = new Watchlist();
+        watchlist.setOwnerUserId(watchlistRequest.getOwnerUserId());
+        watchlist.setMediaItems(watchlistRequest.getMediaItems());
+        watchlist.setIsPubliclyViewable(watchlistRequest.isIsPubliclyViewable());
+
+        WatchlistEntity watchlistEntity = ConvertWatchlistToEntity(watchlist);
+
+        WatchlistEntity savedEntity = watchlistRepository.save(watchlistEntity);
+
+        // Legacy, does not save correctly
+//        List<WatchlistMedia> mediaList = GetWatchlistMediaFromWatchlist(watchlist);
+//        watchlistMediaRepository.saveAll(mediaList);
+
+        // inefficient, but reuses validation and code to find media id code:
+        for (MediaItem item : watchlist.getMediaItems()) {
+            AddMediaItemToWatchlist(savedEntity.getId(), item);
+        }
+
+        // return final state of the watchlist
+        return GetWatchlistById(savedEntity.getId());
+    }
+
+    public Watchlist GetWatchlistById(UUID id) {
+        Optional<WatchlistEntity> entity = watchlistRepository.findById(id);
+        if (!entity.isPresent()) {
+            return null;
+        }
+
+        List<MediaItem> mediaItems = new ArrayList<>();
+
+        // Get Media information for watchlist
+        List<WatchlistMedia> watchlistItems = watchlistMediaRepository.findAllByWatchlistId(id);
+        for (WatchlistMedia item : watchlistItems) {
+            TitleData titleData = mediaService.getMediaById(item.getMediaId());
+            if (titleData != null) {
+                mediaItems.add(new MediaItem().id(titleData.getId()).name(titleData.getTitle()));
+            }
+        }
+
+        return ConvertWatchlistFromEntity(entity.get(), mediaItems);
+    }
+
+    public void RemoveMediaFromWatchlist(UUID watchlistId, String mediaId)
+    {
+        // Custom delete query did not work. I'm not sure why. This is a work around
+        // that should have similar performance
+        List<WatchlistMedia> mediaItems = watchlistMediaRepository.findAllByWatchlistId(watchlistId);
+        for (WatchlistMedia media : mediaItems) {
+            if (media.getMediaId().equals(mediaId)) {
+                watchlistMediaRepository.deleteById(media.getId());
+            }
+        }
+    }
+
+    public Watchlist AddMediaItemToWatchlist(UUID watchlistId, MediaItem mediaItem)
+    {
+        // Verify watchlist and media item exist
+        if (!watchlistRepository.findById(watchlistId).isPresent()) {
+            // TODO: Handle properly to result in 404
+            throw new RuntimeException("Watchlist not found!");
+        }
+
+        ValidateMediaItemForInsertion(mediaItem);
+
+
+        WatchlistMedia watchlistMedia = new WatchlistMedia();
+        watchlistMedia.setWatchlistId(watchlistId);
+
+        if (mediaItem.getId() != null) {
+            if (mediaService.getMediaById(mediaItem.getId()) == null) {
+                // TODO: Handle exception for proper http code
+                throw new RuntimeException("Provided id does not match a movie title");
+            }
+
+            watchlistMedia.setMediaId(mediaItem.getId());
+        }
+        else {
+            // Get the MediaId based on the movie name/title
+            SearchResult result = mediaService.getSearchResultByTitle(mediaItem.getName());
+            if (result == null || result.getId() == null) {
+                // TODO: Handle exception for proper http code
+                throw new RuntimeException("Provided movie title not found");
+            }
+
+            watchlistMedia.setMediaId(result.getId());
+        }
+
+        watchlistMediaRepository.save(watchlistMedia);
+
+        // Return new version of the watchlist
+        return GetWatchlistById(watchlistId);
+    }
+
+    public Watchlist SetWatchlistVisibility(UUID watchlistId, WatchlistVisiblity visibility)
+    {
+        if (visibility.isIsPubliclyViewable() == null) {
+            throw new RuntimeException("isPubliclyViewable parameter not provided");
+        }
+
+        Optional<WatchlistEntity> result = watchlistRepository.findById(watchlistId);
+
+        if (!result.isPresent()) {
+            return null;
+        }
+
+        WatchlistEntity entity = result.get();
+        entity.setIsPubliclyViewable(visibility.isIsPubliclyViewable());
+
+        watchlistRepository.save(entity);
+
+        // return latest version of watchlist
+        return GetWatchlistById(entity.getId());
+    }
+
+    private void ValidateMediaItemForInsertion(MediaItem mediaItem)
+    {
+        String id = mediaItem.getId();
+        String name = mediaItem.getName();
+
+        // TODO: Handle exceptions properly to result in 400
+        if (id != null && name != null) {
+            throw new RuntimeException("Id and Name given. Choose one parameter to add to playlist");
+        }
+        else if (id == null && name == null) {
+            throw new RuntimeException("Id nor Name were given in Request");
+        }
+        else if (id != null && id.isEmpty()) {
+            throw new RuntimeException("Id is empty");
+        }
+        else if (name != null && name.isEmpty()) {
+            throw new RuntimeException("Name is empty");
+        }
+
+    }
+
+    private WatchlistEntity ConvertWatchlistToEntity(Watchlist watchlist) {
+        WatchlistEntity entity = new WatchlistEntity(watchlist.getId(),
+                                                     watchlist.isIsPubliclyViewable(),
+                                                     watchlist.getOwnerUserId());
+
+        return entity;
+    }
+
+    private List<WatchlistMedia> GetWatchlistMediaFromWatchlist(Watchlist entity) {
+        return entity.getMediaItems().stream()
+                .map(mediaItem -> new WatchlistMedia(null, entity.getId(), mediaItem.getId()))
+                .collect(Collectors.toList());
+    }
+
+
+    private Watchlist ConvertWatchlistFromEntity(WatchlistEntity entity, List<MediaItem> mediaItems) {
+//        // Deserialize data to Title data
+//        List<MediaItem> deserializedTitleData = entity.getMediaItems().stream()
+//                // Deserialize into Title data (how it is stored)
+//                .map(mediaCache -> mediaCache.readData(TitleData.class))
+//                // Convert TitleData to MediaItem
+//                .map(titleData -> new MediaItem().id(titleData.getId()).name(titleData.getTitle()))
+//                .collect(Collectors.toList());
+
+        Watchlist watchlist = new Watchlist();
+
+        watchlist.setId(entity.getId());
+        watchlist.setIsPubliclyViewable(entity.getIsPubliclyViewable());
+        watchlist.setMediaItems(mediaItems);
+        watchlist.setOwnerUserId(entity.getOwnerUserId());
+
+        return watchlist;
+    }
+}


### PR DESCRIPTION
The functionality of the API is there. It isn't bulletproof nor completely finished. But this has the basic functionality and can call happy path functionality.

There are a lot of inefficiencies with the database since the Media table contains a blob of data (it was difficult to use the JPA relational feature). I implemented my own table to contain MediaList data for a given Watchlist. Because of this, I have two tables that I need to update... often.

I need to add proper exception handling for validation. I need to add more validation. Also, the "private Watchlist" validation on the calling user only works properly on the GET call. The update calls will allow a non-owning user to update a watchlist and then receive a 404 error (not bulletproof yet).