### PR TITLE
Use Java 11 to deploy to Heroku

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
Refer to this Heroku article on setting Java version to use our specified Java 11 version (from our POM file).